### PR TITLE
Require appsettings.json and clean ConfigHelper

### DIFF
--- a/Capa_Datos/ConfigHelper.cs
+++ b/Capa_Datos/ConfigHelper.cs
@@ -5,20 +5,18 @@ public static class ConfigHelper
 {
     public static string GetConnectionString(string name)
     {
+        var config = new ConfigurationBuilder()
+            .SetBasePath(AppContext.BaseDirectory) // Más confiable que Directory.GetCurrentDirectory()
+            .AddJsonFile("appsettings.json", optional: false)
+            .Build();
+
+        var connectionString = config.GetConnectionString(name);
+
+        if (string.IsNullOrEmpty(connectionString))
         {
-            var config = new ConfigurationBuilder()
-                .SetBasePath(AppContext.BaseDirectory) // Más confiable que Directory.GetCurrentDirectory()
-                .AddJsonFile("appsettings.json", optional: true)
-                .Build();
-
-            var connectionString = config.GetConnectionString(name);
-
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                throw new InvalidOperationException($"No se encontró la cadena de conexión con el nombre '{name}'");
-            }
-
-            return connectionString;
+            throw new InvalidOperationException($"No se encontró la cadena de conexión con el nombre '{name}'");
         }
+
+        return connectionString;
     }
 }


### PR DESCRIPTION
## Summary
- Remove redundant block in `GetConnectionString`
- Make `appsettings.json` mandatory to surface missing configuration

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689bf6a0fc44832588e6785484658914