### PR TITLE
Check configuration file and connection string

### DIFF
--- a/Capa_Datos/Capa_Datos.csproj
+++ b/Capa_Datos/Capa_Datos.csproj
@@ -11,5 +11,11 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.7" />
     <PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/Capa_Datos/ConfigHelper.cs
+++ b/Capa_Datos/ConfigHelper.cs
@@ -1,24 +1,35 @@
-﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration;
+using System;
 using System.IO;
 
 public static class ConfigHelper
 {
     public static string GetConnectionString(string name)
     {
+        var basePath = AppContext.BaseDirectory;
+        var configFile = Path.Combine(basePath, "appsettings.json");
+
+        if (!File.Exists(configFile))
         {
-            var config = new ConfigurationBuilder()
-                .SetBasePath(AppContext.BaseDirectory) // Más confiable que Directory.GetCurrentDirectory()
-                .AddJsonFile("appsettings.json", optional: true)
-                .Build();
-
-            var connectionString = config.GetConnectionString(name);
-
-            if (string.IsNullOrEmpty(connectionString))
-            {
-                throw new InvalidOperationException($"No se encontró la cadena de conexión con el nombre '{name}'");
-            }
-
-            return connectionString;
+            throw new FileNotFoundException(
+                "Configuration file 'appsettings.json' was not found. Verify it exists and is copied to the output directory.",
+                configFile);
         }
+
+        var config = new ConfigurationBuilder()
+            .SetBasePath(basePath) // Más confiable que Directory.GetCurrentDirectory()
+            .AddJsonFile("appsettings.json", optional: false)
+            .Build();
+
+        var connectionString = config.GetConnectionString(name);
+
+        if (string.IsNullOrEmpty(connectionString))
+        {
+            throw new InvalidOperationException(
+                $"Connection string '{name}' was not found. Verify that 'appsettings.json' contains this entry.");
+        }
+
+        return connectionString;
     }
 }
+


### PR DESCRIPTION
## Summary
- Validate presence of appsettings.json before building configuration and throw descriptive FileNotFoundException if missing
- Raise InvalidOperationException when requested connection string is absent, advising to verify appsettings.json
- Copy appsettings.json to the output directory for deployment

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689bfb4b16248325ae0c42d34a368cba